### PR TITLE
Refactor hardcoded-external links to config parameters

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -1,3 +1,10 @@
+urls:
+  source: https://github.com/osu-uwaterloo/osu-uwaterloo-website
+  youtube: https://www.youtube.com/channel/UC_OgDGdaqTI6D_UPtMwCwIg
+  discord: https://discord.gg/mfWqAFg
+  twitch: https://www.twitch.tv/osuuwaterloo
+  email: mailto:osu@clubs.wusa.ca
+
 executives:
   - username: Iconix
     userId: 3898439

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -22,4 +22,4 @@ View osu!uwaterloo's collegiate competition history [here](https://docs.google.c
 
 ## Meta
 
-This website is hosted on the UWaterloo [Computer Science Club](https://csclub.uwaterloo.ca/) servers. This website is built using the [Hugo](https://gohugo.io/) templating engine. The [source code](https://github.com/) is available on GitHub. Members who wish to contribute to the club website development are more than welcome to do so! Instructions on how to do so can be found in the project README.
+This website is hosted on the UWaterloo [Computer Science Club](https://csclub.uwaterloo.ca/) servers. This website is built using the [Hugo](https://gohugo.io/) templating engine. The [source code](https://github.com/osu-uwaterloo/osu-uwaterloo-website) is available on GitHub. Members who wish to contribute to the club website development are more than welcome to do so! Instructions on how to do so can be found in the project README.

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,7 +8,7 @@
   <body>
     <br>
     <div class="container">
-      {{ partial "navbar" }}
+      {{ partial "navbar" . }}
       <hr>
     </div>
     <div class="container">
@@ -17,7 +17,7 @@
     </div>
     <div class="container">
       <hr>
-      {{ partial "footer" }}
+      {{ partial "footer" . }}
     </div>
     <br>
   </body>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,3 +1,3 @@
 <footer>
-    <a href="">source code</a>
+    <a href="{{ $.Site.Params.urls.source }}">source code</a>
 </footer>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -8,9 +8,9 @@
         </div>
     </div>
     <div class="nav-socials">
-        <a href="https://discord.gg/mfWqAFg">{{ partial "svg" "discord" }}</a>
-        <a href="https://www.youtube.com/channel/UC_OgDGdaqTI6D_UPtMwCwIg">{{ partial "svg" "youtube" }}</a>
-        <a href="https://www.twitch.tv/osuuwaterloo">{{ partial "svg" "twitch" }}</a>
-        <a href="mailto:osu@clubs.wusa.ca">{{ partial "svg" "mail" }}</a>
+        <a href="{{ $.Site.Params.urls.discord }}">{{ partial "svg" "discord" }}</a>
+        <a href="{{ $.Site.Params.urls.youtube }}">{{ partial "svg" "youtube" }}</a>
+        <a href="{{ $.Site.Params.urls.twitch }}">{{ partial "svg" "twitch" }}</a>
+        <a href="{{ $.Site.Params.urls.email }}">{{ partial "svg" "mail" }}</a>
     </div>
 </nav>


### PR DESCRIPTION
This PR refactors some external links to become parameters instead of hardcoded values in the HTML template files. This way, we can re-use them more easily in the event that a URL changes.

Future goals (?):
- Add shortcodes for URLs so that we can use the variables in content files
  - https://stackoverflow.com/questions/33373800/use-variable-inside-hugo-content
  - https://gohugo.io/content-management/shortcodes/